### PR TITLE
[FEAT] 카카오 로그인 로직 설계

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(17)
 	}
 }
 
@@ -32,6 +32,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// swagger
+	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.1.0'
 }
 
 tasks.named('test') {

--- a/back/src/main/java/com/thered/stocksignal/apiPayload/ApiResponse.java
+++ b/back/src/main/java/com/thered/stocksignal/apiPayload/ApiResponse.java
@@ -1,0 +1,27 @@
+package com.thered.stocksignal.apiPayload;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"code", "result", "message", "data"})
+public class ApiResponse<T> {
+    private final String code;
+    private final String result;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T data;
+
+    // 성공한 경우 응답 생성
+    public static <T> ApiResponse<T> onSuccess(Status status, T data){
+        return new ApiResponse<>(status.getCode(), status.getResult(), status.getMessage(), data);
+    }
+
+    // 실패한 경우 응답 생성
+//    public static <T> ApiResponse<T> onFailure(Status status){
+//        return new ApiResponse<>(status.getCode(), status.getResult(), status.getMessage());
+//    }
+}

--- a/back/src/main/java/com/thered/stocksignal/apiPayload/Status.java
+++ b/back/src/main/java/com/thered/stocksignal/apiPayload/Status.java
@@ -1,0 +1,35 @@
+package com.thered.stocksignal.apiPayload;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+
+
+@Getter
+@RequiredArgsConstructor(access = PRIVATE)
+public enum Status {
+
+    /**
+     * SUCCESS CODE
+     * 200 : OK
+     * 201 : CREATED
+     * 204 : NO CONTENT
+     * ...
+     */
+
+    /**
+     * FAILURE CODE
+     * 400 :
+     * 401 :
+     * 404 :
+     * ...
+     */
+
+    LOGIN_SUCCESS("200", "SUCCESS", "로그인이 완료되었습니다.");
+
+    private final String code;
+    private final String result;
+    private final String message;
+}

--- a/back/src/main/java/com/thered/stocksignal/app/controller/KakaoLoginController.java
+++ b/back/src/main/java/com/thered/stocksignal/app/controller/KakaoLoginController.java
@@ -1,0 +1,33 @@
+package com.thered.stocksignal.app.controller;
+
+import com.thered.stocksignal.apiPayload.ApiResponse;
+import com.thered.stocksignal.apiPayload.Status;
+import com.thered.stocksignal.app.dto.KakaoLoginDto;
+import com.thered.stocksignal.service.kakao.KakaoLoginService;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth/kakao")
+public class KakaoLoginController {
+
+    private final KakaoLoginService kakaoLoginService;
+
+    @Operation(summary = "프론트로부터 카카오 인가코드 전달받기")
+    @Parameter(name = "code", description = "카카오에서 받은 인카코드, RequestParam")
+    @GetMapping("/login")
+    public ApiResponse<?> kakaoLoginCode(@RequestParam("code") String code){
+        KakaoLoginDto.LoginResponseDto dto = new KakaoLoginDto.LoginResponseDto().builder()
+                .userId(1)
+                .token("1")
+                .build();
+        return ApiResponse.onSuccess(Status.LOGIN_SUCCESS, dto);
+    }
+
+}

--- a/back/src/main/java/com/thered/stocksignal/app/dto/KakaoLoginDto.java
+++ b/back/src/main/java/com/thered/stocksignal/app/dto/KakaoLoginDto.java
@@ -1,0 +1,21 @@
+package com.thered.stocksignal.app.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+public class KakaoLoginDto {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class LoginResponseDto{
+
+        public Integer userId;
+        public String token;
+
+    }
+}

--- a/back/src/main/java/com/thered/stocksignal/repository/UserRepository.java
+++ b/back/src/main/java/com/thered/stocksignal/repository/UserRepository.java
@@ -1,0 +1,4 @@
+package com.thered.stocksignal.repository;
+
+public interface UserRepository {
+}

--- a/back/src/main/java/com/thered/stocksignal/repository/UserRepositoryImpl.java
+++ b/back/src/main/java/com/thered/stocksignal/repository/UserRepositoryImpl.java
@@ -1,0 +1,4 @@
+package com.thered.stocksignal.repository;
+
+public class UserRepositoryImpl implements UserRepository{
+}

--- a/back/src/main/java/com/thered/stocksignal/service/kakao/KakaoLoginService.java
+++ b/back/src/main/java/com/thered/stocksignal/service/kakao/KakaoLoginService.java
@@ -1,0 +1,4 @@
+package com.thered.stocksignal.service.kakao;
+
+public interface KakaoLoginService {
+}

--- a/back/src/main/java/com/thered/stocksignal/service/kakao/KakaoLoginServiceImpl.java
+++ b/back/src/main/java/com/thered/stocksignal/service/kakao/KakaoLoginServiceImpl.java
@@ -1,0 +1,11 @@
+package com.thered.stocksignal.service.kakao;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class KakaoLoginServiceImpl implements KakaoLoginService{
+}

--- a/back/src/main/resources/application.properties
+++ b/back/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=stocksignal


### PR DESCRIPTION
# 🍉 Issue 참고
#4 

# 🌱 API 응답 확인
<img width="1155" alt="image" src="https://github.com/user-attachments/assets/c8d9c6ec-0d50-4241-aa01-662f7b0ef3e3">
<img width="1127" alt="image" src="https://github.com/user-attachments/assets/72d11285-f0a5-4feb-b2c4-c7343034a154">

# 💬 Comment
스웨거로 응답확인 했습니다.
구체적인 로직 설계는 추후 예정입니다.