### PR TITLE
[FEAT] 회원정보 API 응답 구현

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
+		languageVersion = JavaLanguageVersion.of(21)
 	}
 }
 

--- a/back/src/main/java/com/thered/stocksignal/apiPayload/ApiResponse.java
+++ b/back/src/main/java/com/thered/stocksignal/apiPayload/ApiResponse.java
@@ -20,6 +20,7 @@ public class ApiResponse<T> {
         return new ApiResponse<>(status.getCode(), status.getResult(), status.getMessage(), data);
     }
 
+
     // 실패한 경우 응답 생성
 //    public static <T> ApiResponse<T> onFailure(Status status){
 //        return new ApiResponse<>(status.getCode(), status.getResult(), status.getMessage());

--- a/back/src/main/java/com/thered/stocksignal/apiPayload/Status.java
+++ b/back/src/main/java/com/thered/stocksignal/apiPayload/Status.java
@@ -27,7 +27,10 @@ public enum Status {
      * ...
      */
 
-    LOGIN_SUCCESS("200", "SUCCESS", "로그인이 완료되었습니다.");
+    LOGIN_SUCCESS("200", "SUCCESS", "로그인이 완료되었습니다."),
+    GET_USERINFO_SUCCESS("200", "SUCCESS", "회원 정보가 조회되었습니다."),
+    SET_USERINFO_SUCCESS("200", "SUCCESS", "회원 정보가 수정되었습니다."),
+    NICKNAME_SUCCESS("200", "SUCCESS", "사용 가능한 닉네임입니다.");
 
     private final String code;
     private final String result;

--- a/back/src/main/java/com/thered/stocksignal/app/controller/UserInfoController.java
+++ b/back/src/main/java/com/thered/stocksignal/app/controller/UserInfoController.java
@@ -1,0 +1,37 @@
+package com.thered.stocksignal.app.controller;
+
+import com.thered.stocksignal.apiPayload.ApiResponse;
+import com.thered.stocksignal.apiPayload.Status;
+import com.thered.stocksignal.app.dto.UserInfoDto;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
+public class UserInfoController {
+
+    @Operation(summary = "회원 정보 조회")
+    @GetMapping("/info/detail")
+    public ApiResponse<?> getUserInfo(){
+        UserInfoDto.InfoResponseDto infoResponseDto = new UserInfoDto.InfoResponseDto().builder()
+                .nickname("김별명")
+                .build();
+        return ApiResponse.onSuccess(Status.GET_USERINFO_SUCCESS, infoResponseDto);
+    }
+
+    @Operation(summary = "회원 정보 수정")
+    @PatchMapping("/info/edit")
+    public ApiResponse<?> setUserInfo(@RequestBody UserInfoDto.InfoRequestDto dto){
+
+        return ApiResponse.onSuccess(Status.SET_USERINFO_SUCCESS, null);
+    }
+
+    @Operation(summary = "닉네임 중복 확인")
+    @GetMapping("/{nickname}/exists")
+    public ApiResponse<?> isNicknameExists(@PathVariable String nickname){
+
+        return ApiResponse.onSuccess(Status.NICKNAME_SUCCESS, null);
+    }
+}

--- a/back/src/main/java/com/thered/stocksignal/app/dto/UserInfoDto.java
+++ b/back/src/main/java/com/thered/stocksignal/app/dto/UserInfoDto.java
@@ -1,0 +1,24 @@
+package com.thered.stocksignal.app.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserInfoDto {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class InfoResponseDto{
+        public String nickname;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class InfoRequestDto{
+        public String nickname;
+    }
+}


### PR DESCRIPTION
# 🍉 Issue 참고
#6 

# 🌱 API 응답확인

**1. 회원 정보 조회**
<img width="1147" alt="image" src="https://github.com/user-attachments/assets/0c6af41d-cc46-4403-bc33-874c9cb61ac2">
<img width="1144" alt="image" src="https://github.com/user-attachments/assets/488fba66-78ef-412d-bb89-94c8a434d3e0">

**2. 회원 정보 수정**
<img width="1147" alt="image" src="https://github.com/user-attachments/assets/a2c70111-2996-4db4-9d17-9cde4f538af1">
<img width="1145" alt="image" src="https://github.com/user-attachments/assets/be52d4fb-17d7-4183-afeb-4c269f00c4ed">

**3. 닉네임 중복 확인**
<img width="1145" alt="image" src="https://github.com/user-attachments/assets/d4cadded-8865-4608-927c-ca2760107f89">
<img width="1145" alt="image" src="https://github.com/user-attachments/assets/e4f63f33-37ac-42f3-90d3-97e5f146f7e1">

# 💬 Comment
스웨거로 응답확인 했습니다.
구체적인 로직(서비스) 설계 (추후 예정)