### PR TITLE
[FEAT] 주가 정보 조회 API (종목 코드 조회 포함)

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
+		languageVersion = JavaLanguageVersion.of(21)
 	}
 }
 

--- a/back/src/main/java/com/thered/stocksignal/apiPayload/Status.java
+++ b/back/src/main/java/com/thered/stocksignal/apiPayload/Status.java
@@ -27,7 +27,12 @@ public enum Status {
      * ...
      */
 
-    LOGIN_SUCCESS("200", "SUCCESS", "로그인이 완료되었습니다.");
+    LOGIN_SUCCESS("200", "SUCCESS", "로그인이 완료되었습니다."),
+    STOCK_CODE_SUCCESS("200", "SUCCESS", "종목 코드 조회에 성공했습니다."),
+    CURRENT_DATA_SUCCESS("200", "SUCCESS", "현재가 조회에 성공했습니다."),
+    MINUTE_DATA_SUCCESS("200", "SUCCESS", "분봉 조회에 성공했습니다."),
+    PERIOD_DATA_SUCCESS("200", "SUCCESS", "기간별 조회에 성공했습니다."),
+    AI_PREDICTION_SUCCESS("200", "SUCCESS", "AI 예상 주가 조회에 성공했습니다.");
 
     private final String code;
     private final String result;

--- a/back/src/main/java/com/thered/stocksignal/app/controller/StockController.java
+++ b/back/src/main/java/com/thered/stocksignal/app/controller/StockController.java
@@ -1,0 +1,135 @@
+package com.thered.stocksignal.app.controller;
+
+import com.thered.stocksignal.apiPayload.ApiResponse;
+import com.thered.stocksignal.apiPayload.Status;
+import com.thered.stocksignal.app.dto.StockDto.*;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/stock")
+public class StockController {
+
+    @GetMapping("/code/{stockName}")
+    @Operation(summary = "종목 코드 조회", description = "특정 종목 코드를 조회합니다.")
+    public ApiResponse<Object> getStockCode(@PathVariable String stockName) {
+
+        // 예시 데이터
+        StockCodeResponseDto responseDto = StockCodeResponseDto.builder()
+                .stockName(stockName)
+                .stockCode("A123456")
+                .build();
+
+        // 응답
+        return ApiResponse.onSuccess(Status.STOCK_CODE_SUCCESS, responseDto);
+    }
+
+    @GetMapping("/current/{stockName}")
+    @Operation(summary = "현재가 조회", description = "특정 종목의 현재가를 조회합니다.")
+    public ApiResponse<Object> getCurrentData(@PathVariable String stockName) {
+
+        // 예시 데이터
+        CurrentDataResponseDto responseDto = CurrentDataResponseDto.builder()
+                .currentPrice(85000)
+                .openPrice(84000)
+                .highPrice(85500)
+                .lowPrice(83000)
+                .upperLimitPrice(90000)
+                .lowerLimitPrice(80000)
+                .build();
+
+        // 응답
+        return ApiResponse.onSuccess(Status.CURRENT_DATA_SUCCESS, responseDto);
+    }
+
+    @GetMapping("/minute")
+    @Operation(summary = "분봉 조회", description = "특정 종목의 분봉 데이터를 조회합니다.")
+    public ApiResponse<Object> getMinuteData(@RequestParam String stockName, @RequestParam String time) {
+
+        // 예시 데이터
+        List<MinuteDataResponseDto> responseDto = List.of(
+
+                MinuteDataResponseDto.builder()
+                        .date("2022-05-09")
+                        .time("095900")
+                        .openPrice(79000)
+                        .closePrice(80000)
+                        .highPrice(80500)
+                        .lowPrice(78500)
+                        .build(),
+                MinuteDataResponseDto.builder()
+                        .date("2022-05-09")
+                        .time("100000")
+                        .openPrice(79500)
+                        .closePrice(81000)
+                        .highPrice(81500)
+                        .lowPrice(79000)
+                        .build()
+        );
+
+        return ApiResponse.onSuccess(Status.MINUTE_DATA_SUCCESS, responseDto);
+    }
+
+    @GetMapping("/period")
+    @Operation(summary = "기간별 조회", description = "특정 종목의 일봉/주봉/월봉/연봉 데이터를 조회합니다.")
+    public ApiResponse<Object> getPeriodData(
+            @RequestParam String stockName,
+            @RequestParam String startDate,
+            @RequestParam String endDate,
+            @RequestParam String timeFrame) {
+
+        // 예시 데이터
+        List<PeriodDataResponseDto> responseDto = List.of(
+
+                PeriodDataResponseDto.builder()
+                        .date("2022-05-09")
+                        .openPrice(79000)
+                        .closePrice(80000)
+                        .highPrice(80500)
+                        .lowPrice(78500)
+                        .volume(150000)
+                        .build(),
+                PeriodDataResponseDto.builder()
+                        .date("2022-05-08")
+                        .openPrice(78000)
+                        .closePrice(79000)
+                        .highPrice(79500)
+                        .lowPrice(77500)
+                        .volume(120000)
+                        .build()
+        );
+
+        // 응답
+        return ApiResponse.onSuccess(Status.PERIOD_DATA_SUCCESS, responseDto);
+    }
+
+    @GetMapping("/prediction")
+    @Operation(summary = "AI 예상 주가 조회", description = "특정 종목의 AI 예상 주가를 조회합니다.")
+    public ApiResponse<Object> getPrediction(@RequestParam String stockName,
+                                             @RequestParam String timeFrame) {
+
+        // 예시 데이터
+        List<PredictionDataResponseDto> responseDto = List.of(
+
+                PredictionDataResponseDto.builder()
+                        .date("2022-05-09")
+                        .closePrice(90000)
+                        .build(),
+                PredictionDataResponseDto.builder()
+                        .date("2022-05-08")
+                        .closePrice(91000)
+                        .build()
+        );
+
+        // 응답
+        return ApiResponse.onSuccess(Status.AI_PREDICTION_SUCCESS, responseDto);
+    }
+}

--- a/back/src/main/java/com/thered/stocksignal/app/dto/StockDto.java
+++ b/back/src/main/java/com/thered/stocksignal/app/dto/StockDto.java
@@ -1,0 +1,62 @@
+package com.thered.stocksignal.app.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+//날짜에 따라 종가 or 현재가 등 조금씩 필드가 달라져서 가격 클래스를 전부 개별적으로 분리했습니다.
+
+public class StockDto {
+
+    @Getter
+    @Builder
+    // 종목코드
+    public static class StockCodeResponseDto {
+        private String stockName; // 종목 이름
+        private String stockCode; // 종목 코드
+    }
+
+    @Getter
+    @Builder
+    // 현재가 정보
+    public static class CurrentDataResponseDto {
+        private Integer currentPrice;    // 현재가
+        private Integer openPrice;       // 시가
+        private Integer highPrice;       // 고가
+        private Integer lowPrice;        // 저가
+        private Integer upperLimitPrice; // 상한가
+        private Integer lowerLimitPrice; // 하한가
+    }
+
+    @Getter
+    @Builder
+    // 분봉 정보
+    public static class MinuteDataResponseDto {
+        private String date;      // 날짜
+        private String time;      // 시분초
+        private Integer openPrice; // 시가
+        private Integer closePrice; // 종가
+        private Integer highPrice; // 고가
+        private Integer lowPrice;  // 저가
+    }
+
+    @Getter
+    @Builder
+    // 기간별 봉 정보 (일봉이상)
+    public static class PeriodDataResponseDto {
+        private String date;      // 날짜
+        private Integer openPrice; // 시가
+        private Integer closePrice; // 종가
+        private Integer highPrice; // 고가
+        private Integer lowPrice;  // 저가
+        private Integer volume;    //거래량
+    }
+
+    @Getter
+    @Builder
+    // AI 예측 주가 정보
+    public static class PredictionDataResponseDto {
+        private String date;      // 날짜
+        private Integer closePrice; // 종가
+    }
+
+}


### PR DESCRIPTION
# 🍉 Issue 참고
_#을 누르면 ISSUE 번호를 입력할 수 있습니다._
#15 


# 🌱 API 응답 확인 or 🌿 화면 구현 or ..
_구현 스타일에 맞게 제목을 바꿀 수 있습니다._

- 종목 코드 조회 (추후 한투API 호출 시 필요합니다)
![#15 종목코드 req](https://github.com/user-attachments/assets/b1bd3a8c-0526-48f7-9ce1-796635798fa8)
![#15 종목코드 res](https://github.com/user-attachments/assets/e8f843ab-d877-4392-9d86-4b0d80066469)

- 현재가 및 현재데이터 조회
![#15 현재가 req](https://github.com/user-attachments/assets/ec741303-4de2-4770-a242-0eeabf1fcc3f)
![#15 현재가 res](https://github.com/user-attachments/assets/3d7b204a-0819-422e-aa94-4653899d5238)

- 분봉 데이터 조회
![#15 분봉 req](https://github.com/user-attachments/assets/ed78478a-138b-45c8-b02d-d4100086daed)
![#15 분봉 res](https://github.com/user-attachments/assets/ae9759ee-d798-476b-9e54-08ca5469b729)

- 기간별 데이터 조회 (분봉이 아닌 일봉,주봉,월봉,연봉 지원합니다)
![#15 기간별 req](https://github.com/user-attachments/assets/ed323634-da54-410e-9845-95470386aae9)
![#15 기간별 res](https://github.com/user-attachments/assets/af3133ba-ccc1-4ca9-9803-5ae5b8c8ba83)

- AI 예측 데이터 조회 (가장 마지막으로 구현하게 될 예정)
![#15 예측 req](https://github.com/user-attachments/assets/f7839e2d-b5a5-4b1e-a663-bee87bf4832f)
![#15 예측 res](https://github.com/user-attachments/assets/0ef1f642-7fd5-4653-a56e-53acab375f25)


# 💬 Comment
_자유롭게 코멘트 남기면 됩니다._ 

서비스 로직x

한투에서 지원하는 API가 방대해서 노션-backend에 쓸수있는것만 따로 정리해놨습니다. 
https://www.notion.so/proysm/API-fe9139cd631f45f787310ec879f56d63?pvs=4