### PR TITLE
[Bug&Update] 카카오 로그인 토큰 타입 추가

### DIFF
--- a/back/src/main/java/com/thered/stocksignal/app/controller/KakaoLoginController.java
+++ b/back/src/main/java/com/thered/stocksignal/app/controller/KakaoLoginController.java
@@ -24,10 +24,29 @@ public class KakaoLoginController {
 
     @Operation(summary = "프론트로부터 카카오 인가코드 전달받기")
     @Parameter(name = "code", description = "카카오에서 받은 인카코드, RequestParam")
-    @PostMapping("/login")
+    @PostMapping("/login/code")
     public ApiResponse<?> kakaoLoginCode(@RequestParam("code") String code){
 
         String token = kakaoLoginService.getKakaoToken(code);
+        KakaoLoginDto.KakaoUserInfoDto kakaoUserInfoDto = kakaoLoginService.getKakaoUserInfo(token);
+
+        if(userAccountService.findByEmail(kakaoUserInfoDto.getEmail()).isEmpty()) userAccountService.saveKakaoUser(kakaoUserInfoDto.getEmail());
+        User user = userAccountService.findByEmail(kakaoUserInfoDto.getEmail()).get();
+
+        String jwtToken = jwtUtil.createJwt(user.getId(), user.getNickname(), 3600000L);
+        KakaoLoginDto.LoginResponseDto dto = new KakaoLoginDto.LoginResponseDto().builder()
+                .userId(user.getId())
+                .token(jwtToken)
+                .build();
+
+        return ApiResponse.onSuccess(Status.LOGIN_SUCCESS, dto);
+    }
+
+    @Operation(summary = "프론트로부터 카카오 토큰 전달받기")
+    @Parameter(name = "token", description = "카카오에서 받은 토큰, RequestParam")
+    @PostMapping("/login/token")
+    public ApiResponse<?> kakaoLoginToken(@RequestParam("token") String token){
+
         KakaoLoginDto.KakaoUserInfoDto kakaoUserInfoDto = kakaoLoginService.getKakaoUserInfo(token);
 
         if(userAccountService.findByEmail(kakaoUserInfoDto.getEmail()).isEmpty()) userAccountService.saveKakaoUser(kakaoUserInfoDto.getEmail());


### PR DESCRIPTION
## 🍉 ISSUE
#66 

## 🌱 API 응답확인
#### 두 가지 방법 
<img width="1302" alt="image" src="https://github.com/user-attachments/assets/42f3a09c-c0d4-4a7a-8e03-c1955aca59e7">

#### 토큰으로 로그인 성공
<img width="1299" alt="image" src="https://github.com/user-attachments/assets/4f05c422-a2c7-4ff5-aa89-592bdda1b755">


## 💬 Comment
기존 인가코드를 전달받는 형식에서, 토큰을 전달받는 형식을 추가했습니다.

두 가지 모두 사용이 가능하며 더 편한 방법으로 로그인하면 됩니다.