### PR TITLE
[UPDATE] 토큰 시간 이슈 + 신규 기능을 위한 API 변경

### DIFF
--- a/back/src/main/java/com/thered/stocksignal/app/controller/KakaoLoginController.java
+++ b/back/src/main/java/com/thered/stocksignal/app/controller/KakaoLoginController.java
@@ -33,7 +33,7 @@ public class KakaoLoginController {
         if(userAccountService.findByEmail(kakaoUserInfoDto.getEmail()).isEmpty()) userAccountService.saveKakaoUser(kakaoUserInfoDto.getEmail());
         User user = userAccountService.findByEmail(kakaoUserInfoDto.getEmail()).get();
 
-        String jwtToken = jwtUtil.createJwt(user.getId(), user.getNickname(), 3600000L);
+        String jwtToken = jwtUtil.createJwt(user.getId(), user.getNickname());
         KakaoLoginDto.LoginResponseDto dto = new KakaoLoginDto.LoginResponseDto().builder()
                 .userId(user.getId())
                 .token(jwtToken)

--- a/back/src/main/java/com/thered/stocksignal/app/controller/UserInfoController.java
+++ b/back/src/main/java/com/thered/stocksignal/app/controller/UserInfoController.java
@@ -4,7 +4,6 @@ import com.thered.stocksignal.apiPayload.ApiResponse;
 import com.thered.stocksignal.apiPayload.Status;
 import com.thered.stocksignal.app.dto.user.UserInfoDto;
 import com.thered.stocksignal.domain.entity.User;
-import com.thered.stocksignal.jwt.JWTUtil;
 import com.thered.stocksignal.service.user.UserAccountService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -19,7 +18,6 @@ import java.util.Optional;
 public class UserInfoController {
 
     private final UserAccountService userAccountService;
-    private final JWTUtil jwtUtil;
 
     @Operation(summary = "회원 정보 조회", description = "Header에 token을 담아야 합니다.")
     @GetMapping("/info/detail")
@@ -47,7 +45,7 @@ public class UserInfoController {
     @GetMapping("/{nickname}/exists")
     public ApiResponse<?> isNicknameExists(@Parameter @PathVariable(value = "nickname") String nickname){
         Boolean isExists = userAccountService.isExistNickname(nickname);
-        if(isExists == false) return ApiResponse.onSuccess(Status.NICKNAME_SUCCESS, null);
+        if(!isExists) return ApiResponse.onSuccess(Status.NICKNAME_SUCCESS, null);
         return ApiResponse.onSuccess(Status.NICKNAME_INVALID, null);
     }
 
@@ -60,7 +58,7 @@ public class UserInfoController {
         if(userId == -1) return ApiResponse.onSuccess(Status.TOKEN_INVALID, null);
 
         Optional<User> user = userAccountService.findById(userId);
-        if(user.get().getIsKisLinked() == false) userAccountService.connectKisAccount(userId, dto);
+        if(!user.get().getIsKisLinked()) userAccountService.connectKisAccount(userId, dto);
 
         return ApiResponse.onSuccess(Status.KIS_CONNECT_SUCCESS, null);
     }

--- a/back/src/main/java/com/thered/stocksignal/app/dto/StockDto.java
+++ b/back/src/main/java/com/thered/stocksignal/app/dto/StockDto.java
@@ -20,7 +20,10 @@ public class StockDto {
     // 일봉
     public static class DailyPriceResponseDto {
         private String date;      // 날짜
+        private Long startPrice; // 시가
         private Long closePrice; // 종가
+        private Long highPrice; // 고가
+        private Long lowPrice; // 저가
         private Long tradingVolume;    //거래량
     }
 

--- a/back/src/main/java/com/thered/stocksignal/jwt/AppLoginFilter.java
+++ b/back/src/main/java/com/thered/stocksignal/jwt/AppLoginFilter.java
@@ -50,7 +50,7 @@ public class AppLoginFilter extends UsernamePasswordAuthenticationFilter {
 
         UserCustomDto userCustomDto = (UserCustomDto) authentication.getPrincipal();
 
-        String token = jwtUtil.createJwt(userCustomDto.getUserId(), userCustomDto.getUserNickname(), 60 * 60 * 1000L); // 만료 시간 1시간 설정
+        String token = jwtUtil.createJwt(userCustomDto.getUserId(), userCustomDto.getUserNickname());
 
         response.addHeader("Authorization", "Bearer " + token);
     }

--- a/back/src/main/java/com/thered/stocksignal/jwt/JWTFilter.java
+++ b/back/src/main/java/com/thered/stocksignal/jwt/JWTFilter.java
@@ -33,12 +33,6 @@ public class JWTFilter extends OncePerRequestFilter {
 
         String token = authorization.split(" ")[1]; //Bearer 부분 제거 후 순수 토큰만 획득
 
-        if (jwtUtil.isExpired(token)) {
-            System.out.println("token expired");
-            filterChain.doFilter(request, response);
-            return; // 조건이 해당되면 메소드 종료 (필수)
-        }
-
         Long userId = jwtUtil.getUserId(token);
         String nickname = jwtUtil.getNickname(token);
 

--- a/back/src/main/java/com/thered/stocksignal/jwt/JWTUtil.java
+++ b/back/src/main/java/com/thered/stocksignal/jwt/JWTUtil.java
@@ -40,25 +40,12 @@ public class JWTUtil {
         return claims.get("nickname", String.class);
     }
 
-    public Boolean isExpired(String token) {
-
-        Date expiration = Jwts.parserBuilder()
-                .setSigningKey(secretKey)
-                .build()
-                .parseClaimsJws(token)
-                .getBody()
-                .getExpiration();
-
-        return expiration.before(new Date());
-    }
-
-    public String createJwt(Long userId, String nickname, Long expiredMs) {
+    public String createJwt(Long userId, String nickname) {
 
         return Jwts.builder()
                 .claim("userId", userId)
                 .claim("nickname", nickname)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + expiredMs))
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
     }

--- a/back/src/main/java/com/thered/stocksignal/service/company/CompanyServiceImpl.java
+++ b/back/src/main/java/com/thered/stocksignal/service/company/CompanyServiceImpl.java
@@ -197,7 +197,10 @@ public class CompanyServiceImpl implements CompanyService {
                 DailyPriceResponseDto dailyPrice = DailyPriceResponseDto.builder().build();
 
                 dailyPrice.setDate(dailyNode.path("stck_bsop_date").asText());   // 날짜
+                dailyPrice.setStartPrice(dailyNode.path("stck_oprc").asLong());   // 시가
                 dailyPrice.setClosePrice(dailyNode.path("stck_clpr").asLong());   // 종가
+                dailyPrice.setHighPrice(dailyNode.path("stck_hgpr").asLong());   // 고가
+                dailyPrice.setLowPrice(dailyNode.path("stck_lwpr").asLong());   // 저가
                 dailyPrice.setTradingVolume(dailyNode.path("acml_vol").asLong());   // 거래량
 
                 dailyPriceList.add(dailyPrice);

--- a/back/src/main/java/com/thered/stocksignal/service/user/UserAccountServiceImpl.java
+++ b/back/src/main/java/com/thered/stocksignal/service/user/UserAccountServiceImpl.java
@@ -81,7 +81,7 @@ public class UserAccountServiceImpl implements UserAccountService{
     @Override
     public void connectKisAccount(Long userId, UserInfoDto.kisAccountRequestDto dto) {
         Optional<User> user = userRepository.findById(userId);
-        if(user == null) throw new IllegalArgumentException("존재하지 않는 userId 입니다 : " + userId);
+        if(user.isEmpty()) throw new IllegalArgumentException("존재하지 않는 userId 입니다 : " + userId);
         User updateUser = user.get();
 
         updateUser.setKisAccount(dto.getSecretKey(), dto.getAppKey(), dto.getAccount(), true);
@@ -139,7 +139,13 @@ public class UserAccountServiceImpl implements UserAccountService{
         try{
             tokenResponseDto = objectMapper.readValue(response.getBody(), KisAccountDto.AccessTokenResponseDto.class);
             String newAccessToken = tokenResponseDto.getAccess_token();
-            String newTokenExpired = tokenResponseDto.getAccess_token_token_expired();
+
+            Calendar calendar = Calendar.getInstance();
+            calendar.setTime(new Date());
+            calendar.add(Calendar.HOUR, 15);    // utc시간차 고려
+
+            String newTokenExpired = DateUtil.formatDate(calendar.getTime());
+
             editKisAccessToken(user.getId(), newAccessToken, newTokenExpired);
         }catch(JsonMappingException e){
             e.printStackTrace();
@@ -201,7 +207,7 @@ public class UserAccountServiceImpl implements UserAccountService{
 
             Calendar calendar = Calendar.getInstance();
             calendar.setTime(new Date());
-            calendar.add(Calendar.HOUR, 24);
+            calendar.add(Calendar.HOUR, 15);    // utc시간차 고려
 
             String newSocketKeyExpired = DateUtil.formatDate(calendar.getTime());
 

--- a/back/src/main/java/com/thered/stocksignal/websocket/WebSocketHandler.java
+++ b/back/src/main/java/com/thered/stocksignal/websocket/WebSocketHandler.java
@@ -341,7 +341,7 @@ public class WebSocketHandler extends TextWebSocketHandler {
             for(Scenario scenario : scenarios){
                 String companyCode = scenario.getCompany().getCompanyCode();
                 String companyName = scenario.getCompany().getCompanyName();
-                String token = jwtUtil.createJwt(userId, nickname, expirationTime);
+                String token = jwtUtil.createJwt(userId, nickname);
 
                 // 각 사용자마다 연결
                 handleKisSocketRequest(token, userId, companyCode, null, "1");


### PR DESCRIPTION
- (신규 기능 목적) 일봉조회시 시가/종가/고가/저가를 함께 리턴하도록 수정
- 토큰 만료기한 제거
- 한투에서 제공하는 토큰 만료시간이 ec2 utc시간 기준대와 달라 발생하는 문제 수정 