### PR TITLE
[FIX] 웹소켓 주소 접근 허용

### DIFF
--- a/back/src/main/java/com/thered/stocksignal/jwt/SecurityConfig.java
+++ b/back/src/main/java/com/thered/stocksignal/jwt/SecurityConfig.java
@@ -53,6 +53,7 @@ public class SecurityConfig {
         http.httpBasic((auth) -> auth.disable());
 
         http.authorizeHttpRequests((auth) -> auth
+                .requestMatchers("/stocksignal").permitAll()
                 .requestMatchers("/**", "/").permitAll()
                 .requestMatchers(PERMIT_URL_ARRAY).permitAll()
                 .anyRequest().authenticated());


### PR DESCRIPTION
SecurityConfig에서 .requestMatchers("/stocksignal").permitAll() 추가했습니다.
(웹소켓 주소 접근 허용)